### PR TITLE
Refactor image to be ingested as single zip file instead of indiv fil…

### DIFF
--- a/image_ingest.py
+++ b/image_ingest.py
@@ -60,7 +60,6 @@ def ingest_image(call_timestamp=getCurrentDateTime()):
         zip_filename = iso_datetime + ".zip"
         # upload image to S3
         with open(zip_filename, "rb") as f:
-            print(zip_filename)
             img_bucket.upload_fileobj(Fileobj=f, Key=CAM_IMG_DIR + zip_filename)
         print("Completed image upload to S3 at " + str(call_timestamp))
         os.remove(zip_filename)

--- a/image_ingest.py
+++ b/image_ingest.py
@@ -1,5 +1,5 @@
+import shutil
 import sys
-import datetime
 import boto3
 import os
 
@@ -40,6 +40,9 @@ def ingest_image(call_timestamp=getCurrentDateTime()):
     timestamp, cameras = itemgetter("timestamp", "cameras")(item)
     iso_datetime = formatted_timestamp(call_timestamp)
 
+    if not os.path.exists(CAM_IMG_DIR):
+        os.makedirs(CAM_IMG_DIR)
+
     for camera in cameras:
         image, location, camera_id, image_metadata = itemgetter(
             "image", "location", "camera_id", "image_metadata"
@@ -48,9 +51,20 @@ def ingest_image(call_timestamp=getCurrentDateTime()):
         file_name = CAM_IMG_DIR + iso_datetime + "_" + camera_id + ".jpg"
         # get image stream
         img_resp = get_req_handler(image)
-        try:
-            # upload image to S3
-            img_bucket.put_object(Body=img_resp.content, Key=file_name)
-        except Exception:
-            print("Failed to upload image " + file_name, file=sys.stderr)
-    print("Completed image upload to S3 at " + str(call_timestamp))
+
+        with open(file_name, "wb") as f:
+            f.write(img_resp.content)
+
+    try:
+        shutil.make_archive(iso_datetime, "zip", CAM_IMG_DIR)
+        zip_filename = iso_datetime + ".zip"
+        # upload image to S3
+        with open(zip_filename, "rb") as f:
+            print(zip_filename)
+            img_bucket.upload_fileobj(Fileobj=f, Key=CAM_IMG_DIR + zip_filename)
+        print("Completed image upload to S3 at " + str(call_timestamp))
+        os.remove(zip_filename)
+    except Exception:
+        print("Failed to upload images " + CAM_IMG_DIR, file=sys.stderr)
+    finally:
+        shutil.rmtree(CAM_IMG_DIR)


### PR DESCRIPTION
## Changes in this PR

- [ ] Bug fix
- [x] New feature
- [x] Breaking change of an existing feature
- [x] Refactor/Performance enhancements

## Overview

- Images are zipped and uploaded on S3 instead of being stored individually
