### PR TITLE
handle bing API error when no resource received

### DIFF
--- a/bing_map_ingest.py
+++ b/bing_map_ingest.py
@@ -1,6 +1,7 @@
 import ast
 import os
 
+import numpy as np
 import pandas as pd
 import json
 from io import StringIO
@@ -58,7 +59,10 @@ def call_route_API(
     resp_content = json.loads(resp.content.decode("utf-8"))
 
     # for short route before and after the camera, there should be 1 resource
-    resource = resp_content["resourceSets"][0]["resources"][0]
+    try:
+        resource = resp_content["resourceSets"][0]["resources"][0]
+    except Exception:
+        resource = {}
 
     extract_vals = {
         "camera_id": [camera_id],
@@ -78,7 +82,7 @@ def call_route_API(
         try:
             v = itemgetter(f)(resource)
         except KeyError:
-            v = []
+            v = np.NaN
         extract_vals[f] = [v]
 
     extract_frame = pd.DataFrame(extract_vals)


### PR DESCRIPTION
## Changes in this PR

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change of an existing feature
- [ ] Refactor/Performance enhancements

## Overview

- if bing API response doesn't return a resource, resource is taken as empty dictionary, the traffic congestion data is filled with np.NaNs
