### PR TITLE
Push super table to AWS Redshift

### DIFF
--- a/db/ddl.py
+++ b/db/ddl.py
@@ -11,7 +11,6 @@ cursor = conn.cursor()
 cursor.execute(
     """
     CREATE TABLE traffic_weather_comb (
-    id SERIAL PRIMARY KEY,
     call_timestamp varchar,
     cam_id int,
     direction int,
@@ -76,8 +75,7 @@ cursor.execute(
     twenty_four_hr_period_3_start varchar,
     twenty_four_hr_period_3_end varchar,
     twenty_four_hr_period_3 varchar,
-    trafficcongestion varchar,
-    created_on timestamp default NOW()
+    trafficcongestion varchar
     )
   """
 )

--- a/db/ddl.py
+++ b/db/ddl.py
@@ -75,7 +75,8 @@ cursor.execute(
     twenty_four_hr_period_3_start varchar,
     twenty_four_hr_period_3_end varchar,
     twenty_four_hr_period_3 varchar,
-    trafficcongestion varchar
+    trafficcongestion varchar,
+    PRIMARY KEY(call_timestamp,cam_id,direction)
     )
   """
 )

--- a/super_table_pyspark.py
+++ b/super_table_pyspark.py
@@ -1,6 +1,7 @@
+from datetime import datetime
 from pprint import pprint
 import re
-from db.super_tbl import copy_csv_to_db
+from db.super_tbl import copy_csv_to_db, spark_df_to_db
 
 
 from helper import (
@@ -42,12 +43,15 @@ weather_dir = os.environ["WEATHER_DATA_DIR"]
 bing_dir = os.environ["BING_DATA_DIR"]
 
 # Spark Config
+# can vary number of cores used for local, and number of cores/memory for driver/executors, see:
+# https://stackoverflow.com/questions/32356143/what-does-setmaster-local-mean-in-spark
+# https://stackoverflow.com/questions/24622108/apache-spark-the-number-of-cores-vs-the-number-of-executors
+# https://stackoverflow.com/questions/63387253/pyspark-setting-executors-cores-and-memory-local-machine
+# using more cores may be slower due to data I/O
 spark = (
-    # can vary number of cores used for local, and number of cores/memory for driver/executors
-    # see: https://stackoverflow.com/questions/32356143/what-does-setmaster-local-mean-in-spark
-    # and: https://stackoverflow.com/questions/24622108/apache-spark-the-number-of-cores-vs-the-number-of-executors
-    # using more cores can be slower due to data I/O
     SparkSession.builder.master("local[4]")
+    # JDBC to postgres requires driver from https://mvnrepository.com/artifact/org.postgresql/postgresql/42.3.3
+    .config("spark.jars.packages", "org.postgresql:postgresql:42.3.3")
     .config("spark.driver.cores", 8)
     .config("spark.driver.memory", "8g")
     .config("spark.executor.cores", 4)
@@ -367,6 +371,11 @@ def proc_forecast_4DAY(call_timestamp=None):
         "4day_update_timestamp_4",
     ]
     forecast_4d = forecast_4d.drop(*drop_cols)
+
+    # rename columns to start with alphabets
+    forecast_4d = forecast_4d.toDF(
+        *["four_" + c[1:] if c.startswith("4") else c for c in forecast_4d.columns]
+    )
     return forecast_4d
 
 
@@ -435,7 +444,13 @@ def proc_forecast_24HR(call_timestamp=None):
         .join(long_df_dict[2], how="inner", on=["call_timestamp", "compass"])
         .join(long_df_dict[3], how="inner", on=["call_timestamp", "compass"])
     )
-
+    # rename columns to start with alphabets
+    forecast_24h = forecast_24h.toDF(
+        *[
+            "twenty_four_" + c[2:] if c.startswith("24") else c
+            for c in forecast_24h.columns
+        ]
+    )
     return forecast_24h
 
 
@@ -449,6 +464,10 @@ def proc_forecast_2HR(call_timestamp=None):
     forecast_2h = get_df_from_csv("forecast-2HR.csv", weather_dir)
     # Process 2h
     forecast_2h = forecast_2h.drop("2hr_forecast_area_loc", "2hr_start", "2hr_end")
+    # rename columns to start with alphabets
+    forecast_2h = forecast_2h.toDF(
+        *["two_" + c[1:] if c.startswith("2") else c for c in forecast_2h.columns]
+    )
     return forecast_2h
 
 
@@ -467,14 +486,28 @@ def proc_bing(call_timestamp=None):
     bing_key_table = bing_key_table.select("camera_id", "direction").withColumnRenamed(
         "camera_id", "cam_id"
     )
-    bing_data = bing_data.select(
-        "camera_id", "direction", "call_timestamp", "trafficCongestion"
-    ).withColumnRenamed("camera_id", "cam_id")
+    bing_data = (
+        bing_data.select(
+            "camera_id", "direction", "call_timestamp", "trafficCongestion"
+        )
+        .withColumnRenamed("camera_id", "cam_id")
+        .withColumnRenamed("trafficCongestion", "trafficcongestion")
+    )
 
     return bing_key_table, bing_data
 
 
-def get_super_table(call_timestamp=None):
+def get_super_table(
+    call_timestamp=None,
+    push_to_DB="spark",
+    dest_table="traffic_weather_comb",
+    write_mode="append",
+):
+    # if write mode specified as append (default), then only append the rows from today to the DB
+    # otherwise, overwrite the DB with all rows in the source CSVs (can use overwrite mode to benchmark spark performance)
+    assert (
+        write_mode == "append" or write_mode == "overwrite"
+    ), "write_mode should be one of 'append', 'overwrite'"
 
     # Camera to locations -
     # TODO: perhaps run mapping function one time & pull from S3 instead
@@ -484,7 +517,7 @@ def get_super_table(call_timestamp=None):
     cam_to_loc = (
         cam_to_loc.withColumnRenamed("rainfall", "rainfall_station_id")
         .withColumnRenamed("not_rainfall", "non_rainfall_station_id")
-        .withColumnRenamed("region", "2hr_forecast_area")
+        .withColumnRenamed("region", "two_hr_forecast_area")
     )
 
     print("Camera-Station Mapping DF:")
@@ -531,6 +564,11 @@ def get_super_table(call_timestamp=None):
         .intersect(bing_data.select("call_timestamp"))
         .distinct()
     )
+    if write_mode == "append":
+        print("Writing rows for the date:", datetime.today)
+        all_time = all_time.filter(
+            F.to_date(F.col("call_timestamp")).eqNullSafe(F.current_date())
+        )
 
     base_df = all_time.join(cam_all, how="cross")
 
@@ -542,26 +580,37 @@ def get_super_table(call_timestamp=None):
         on=["call_timestamp", "non_rainfall_station_id"],
         how="left",
     )
-    df3 = df2.join(forecast_2h, on=["call_timestamp", "2hr_forecast_area"], how="left")
+    df3 = df2.join(
+        forecast_2h, on=["call_timestamp", "two_hr_forecast_area"], how="left"
+    )
     df4 = df3.join(forecast_4d, on=["call_timestamp"])
     df5 = df4.join(forecast_24h, on=["call_timestamp", "compass"])
-    df6 = df5.join(bing_data, on=["call_timestamp", "cam_id", "direction"])
+    df6 = df5.join(bing_data, on=["call_timestamp", "cam_id", "direction"]).sort(
+        "call_timestamp"
+    )
 
     # writing super table to a CSV locally for now
     # TODO: push table to redshift, also do so for the other smaller tables
-    print("start copy to DB:", getCurrentDateTime())
-    pd_df6 = df6.toPandas()
-    if isinstance(pd_df6, pd.DataFrame):
-        # use pd DF to_csv method to write to single csv sT.csv (csv has no header to allow easy insertion into db)
-        file_path = "sT.csv"
-        pd_df6.to_csv(file_path, index=False, header=False)
-        with open(file_path) as f:
-            copy_csv_to_db(f)
-        print("end:", getCurrentDateTime())
-    else:
+    print(f"start copy to DB using {push_to_DB}:", getCurrentDateTime())
+    if push_to_DB == "pandas":
+        pd_df6 = df6.toPandas()
+        if isinstance(pd_df6, pd.DataFrame):
+            # use pd DF to_csv method to write to single csv sT.csv (csv has no header to allow easy insertion into db)
+            file_path = "sT.csv"
+            pd_df6.to_csv(file_path, index=False, header=False)
+            with open(file_path) as f:
+                copy_csv_to_db(f)
+            print("end:", getCurrentDateTime())
+    elif push_to_DB == "spark":
+        spark_df_to_db(df6, table_name=dest_table, write_mode=write_mode)
+        print(f"write to Redshift DB Table {dest_table} done at:", getCurrentDateTime())
+
         # use spark API to write into dir sT/
-        df6.repartition(1).write.csv("sT", header=True, mode="overwrite")
+        df6.repartition(1).write.csv("sT", header=True, mode=write_mode)
+        print("write to local csv done at:", getCurrentDateTime())
     return df6
 
 
-sT = get_super_table()
+sT = get_super_table(
+    push_to_DB="spark", dest_table="traffic_weather_comb_spark", write_mode="append"
+)


### PR DESCRIPTION
## Changes in this PR

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change of an existing feature
- [ ] Refactor/Performance enhancements

## Overview

### db/ddl.py

- remove id and created_on fields from DB

### db/super_tbl.py 
- helper function to write spark df contents to AWS Redshift Postgres DB
- this function requires that spark config in the calling script include the JDBC driver
- Spark configuration could be shifted to .env instead

### super_table_pyspark.py
- added JBDC Driver package to config
- changed column names to start with alphabets & use snake case in alignment with schema defined in db/ddl.py
- arguments added to get_super_table to decide:
   - overwrite DB table contents with all rows from source CSVs or append rows for the current day only
   - whether to write directly from spark df or convert to pandas df in driver, save to local csv and write that instead